### PR TITLE
Correct R53 Record and Domain Names, Redirect HTTP to HTTPS

### DIFF
--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -2,7 +2,7 @@ name: 1. Configure and Test Actions
 
 on:
   push:
-    branches: [ "main", "correct-prefix" ]
+    branches: [ "main" ]
 
 env:
   AWS_REGION: "us-east-1"

--- a/.github/workflows/config.yml
+++ b/.github/workflows/config.yml
@@ -2,7 +2,7 @@ name: 1. Configure and Test Actions
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "correct-prefix" ]
 
 env:
   AWS_REGION: "us-east-1"

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -8,7 +8,6 @@ import { S3Origin } from 'aws-cdk-lib/aws-cloudfront-origins';
 import { ARecord, HostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53';
 import { CloudFrontTarget } from 'aws-cdk-lib/aws-route53-targets';
 import { Certificate, CertificateValidation } from 'aws-cdk-lib/aws-certificatemanager';
-import { HttpsRedirect } from 'aws-cdk-lib/aws-route53-patterns';
 
 export class CdkStack extends cdk.Stack {
   constructor(scope: Construct, id: string, props: cdk.StackProps) {

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -82,14 +82,14 @@ export class CdkStack extends cdk.Stack {
         viewerProtocolPolicy: ViewerProtocolPolicy.ALLOW_ALL,
         allowedMethods: AllowedMethods.ALLOW_ALL,
       },
-      domainNames: ["devopsdsm.com"],
+      domainNames: ["devopsdsm.com", "www.devopsdsm.com"],
       certificate: cert
     });
 
     const aliasRecord = new ARecord(this, 'r53-record-to-cfn-distro', {
       target: RecordTarget.fromAlias(new CloudFrontTarget(cfnDistro)),
       zone: hostedZone,
-      recordName: 'CloudFront-Distribution-Record'
+      recordName: 'www'
     });
 
   }

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -70,7 +70,7 @@ export class CdkStack extends cdk.Stack {
     });
 
     const cert = new Certificate(this, 'devops-dsm-cert', {
-      domainName: "devopsdsm.com",
+      domainName: "*.devopsdsm.com", 
       validation: CertificateValidation.fromDns(hostedZone)
     });
 

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -87,7 +87,7 @@ export class CdkStack extends cdk.Stack {
       certificate: cert
     });
 
-    new ARecord(this, 'r53-www-record-to-cfn-distro', {
+    new ARecord(this, 'r53-record-to-cfn-distro', {
       target: RecordTarget.fromAlias(new CloudFrontTarget(cfnDistro)),
       zone: hostedZone,
       recordName: 'www'
@@ -98,6 +98,7 @@ export class CdkStack extends cdk.Stack {
       zone: hostedZone,
       recordName: ''
     });
+
 
   }
 }

--- a/cdk/lib/cdk-stack.ts
+++ b/cdk/lib/cdk-stack.ts
@@ -87,13 +87,13 @@ export class CdkStack extends cdk.Stack {
       certificate: cert
     });
 
-    new ARecord(this, 'r53-record-to-cfn-distro', {
+    new ARecord(this, 'r53-www-record-to-cfn-distro', {
       target: RecordTarget.fromAlias(new CloudFrontTarget(cfnDistro)),
       zone: hostedZone,
       recordName: 'www'
     });
 
-    new ARecord(this, 'r53-record-to-cfn-distro', {
+    new ARecord(this, 'r53-blank-record-to-cfn-distro', {
       target: RecordTarget.fromAlias(new CloudFrontTarget(cfnDistro)),
       zone: hostedZone,
       recordName: ''


### PR DESCRIPTION
- Correct Cert for domain *.devopsdsm.com
- Redirect HTTP to HTTPS in CFN Distro
- Add www.devopsdsm.com to domain name in CFN Distro
- Correct www record name in R53 ARecord
- Add '' record name in R53 ARecord